### PR TITLE
📼 Asset check

### DIFF
--- a/mario/pipelines/pipeline.py
+++ b/mario/pipelines/pipeline.py
@@ -1,5 +1,4 @@
 from metaflow import FlowSpec, Parameter, kubernetes, secrets, step, trigger
-
 from utils import PipelineUtils
 
 
@@ -21,7 +20,7 @@ class Pipeline(FlowSpec, PipelineUtils):
 
     @secrets(sources=['CLAMS-SonyCi-API', 'CLAMS-chowda-secret'])
     @kubernetes(
-        image='ghcr.io/wgbh-mla/chowda:pr-134',
+        image='ghcr.io/wgbh-mla/chowda:main',
         persistent_volume_claims={'media-pvc': '/m'},
     )
     @step

--- a/mario/pipelines/pipeline.py
+++ b/mario/pipelines/pipeline.py
@@ -33,9 +33,13 @@ class Pipeline(FlowSpec, PipelineUtils):
 
         self.input_mmif = self.mmif
         if not self.mmif or self.mmif == 'null':
-            print('No mmif provided, downloading from clams', self.type)
-            self.get_mmif()
-            print('Got mmif')
+            print('No mmif provided, checking database for existing mmif')
+            self.input_mmif = self.get_mmif_from_database()
+            if not self.input_mmif:
+                print('No mmif found, creating new mmif')
+                self.input_mmif = self.create_new_mmif()
+        assert self.input_mmif, 'Problem getting mmif'
+        print('Got mmif')
         print(self.input_mmif)
 
         self.download_media_file()

--- a/mario/pipelines/utils.py
+++ b/mario/pipelines/utils.py
@@ -14,8 +14,14 @@ class PipelineUtils:
             media_file = db.exec(
                 select(MediaFile).where(MediaFile.guid == self.guid)
             ).one()
-            self.asset_id = media_file.assets[0].id
-            self.asset_name = media_file.assets[0].name
+            assets = [
+                asset
+                for asset in media_file.assets
+                if asset.name.endswith(('.mp4', '.mp3'))
+            ]
+            assert assets, f'No {self.media_type} asset found for {self.guid}'
+            self.asset_id = assets[0].id
+            self.asset_name = assets[0].name
             self.type = media_file.assets[0].type.value.lower()
             self.filename = join('/m', self.asset_name)
 

--- a/mario/pipelines/utils.py
+++ b/mario/pipelines/utils.py
@@ -14,16 +14,6 @@ class PipelineUtils:
             media_file = db.exec(
                 select(MediaFile).where(MediaFile.guid == self.guid)
             ).one()
-            assets = [
-                asset
-                for asset in media_file.assets
-                if asset.name.endswith(('.mp4', '.mp3'))
-            ]
-            assert assets, f'No {self.media_type} asset found for {self.guid}'
-            self.asset_id = assets[0].id
-            self.asset_name = assets[0].name
-            self.type = media_file.assets[0].type.value.lower()
-            self.filename = join('/m', self.asset_name)
 
             # Add the Metaflow Run to the database
             batch = db.get(Batch, self.batch_id)
@@ -35,7 +25,31 @@ class PipelineUtils:
             db.add(new_metaflow_run)
             db.commit()
 
-    def get_mmif(self):
+            # Filter for media assets
+            assets = [
+                asset
+                for asset in media_file.assets
+                if asset.name.endswith(('.mp4', '.mp3'))
+            ]
+            assert assets, f'No media assets found for {self.guid}'
+            asset = assets[0]
+            self.asset_id = asset.id
+            self.asset_name = asset.name
+            self.type = asset.type.value.lower()
+            self.filename = join('/m', self.asset_name)
+
+    def get_mmif_from_database(self):
+        from chowda.db import engine
+        from chowda.models import MediaFile
+        from sqlmodel import Session, select
+
+        with Session(engine) as db:
+            media_file = db.exec(
+                select(MediaFile).where(MediaFile.guid == self.guid)
+            ).one()
+            return media_file.mmif_json
+
+    def create_new_mmif(self):
         from requests import post
 
         self.input_mmif = post(


### PR DESCRIPTION
# Asset check
Pipeline now checks assets and filters for media only: `.mp3, .mp4`

Raises an error if no media found.

Closes #15

Closes WGBH-MLA/chowda#117