### PR TITLE
🩹 `&` Escaping

### DIFF
--- a/mario/pipelines/pipeline.py
+++ b/mario/pipelines/pipeline.py
@@ -53,9 +53,9 @@ class Pipeline(FlowSpec, PipelineUtils):
     def run_pipeline(self):
         """Run the mmif through a CLAMS pipeline"""
         mmif = self.input_mmif
-        print('starting pipeline')
-        print(self.pipeline)
-        for app in self.pipeline:
+        pipeline = self.clean_pipeline()
+        print('starting pipeline', pipeline)
+        for app in pipeline:
             print(f'Running {app}')
             mmif = self.app(app, mmif)
             print(f'{app} done')

--- a/mario/pipelines/trigger.py
+++ b/mario/pipelines/trigger.py
@@ -1,0 +1,22 @@
+from metaflow import FlowSpec, Parameter, step, trigger
+
+
+@trigger(event='ampersand')
+class TriggerPipeline(FlowSpec):
+    guid = Parameter('guid', help='GUID of the transcript to process')
+    pipeline = Parameter(
+        'pipeline', help='Testing "&" handling in flow parameters', separator=','
+    )
+
+    @step
+    def start(self):
+        print(f'Checking {self.pipeline} for "&" handling')
+        self.next(self.end)
+
+    @step
+    def end(self):
+        print('Done!')
+
+
+if __name__ == '__main__':
+    TriggerPipeline()

--- a/mario/pipelines/utils.py
+++ b/mario/pipelines/utils.py
@@ -189,3 +189,24 @@ class PipelineUtils:
             remove(f)
             cleaned += 1
         print(f'Cleaned up {cleaned} files')
+
+    def clean_pipeline(self) -> list:
+        """Clean pipeline strings
+
+        This is needed to restore `&` characters replaced by `\u0026` in the pipeline Parameter,
+        which is a result of ArgoEvent's parsing of the pipeline URL string as a body payload parameter,
+        which is written to the Argo-workflow kubernetes resource using `| toJson`,
+        which wraps the GoLang `json.Marshal` function, which escapes `&`, `<`, and `>` characters to HTML safe unicode.
+        This shows up as "\\u0026" in the python string.
+
+        See https://github.com/WGBH-MLA/chowda/issues/204
+        """
+
+        return [
+            app.replace('\\u0026', '&')
+            .replace('\\u0028', '(')
+            .replace('\\u0029', ')')
+            .replace('\\u003c', '<')
+            .replace('\\u003e', '>')
+            for app in self.pipeline
+        ]


### PR DESCRIPTION
# `&`
Patches production bug where app URL `&`s become `\\u0026`.

Closes https://github.com/WGBH-MLA/chowda/issues/204 